### PR TITLE
Allow auto install on all system

### DIFF
--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -16,15 +16,29 @@ To install **Oasis** with a single command, run:
 
 ## 2) Manual Installation 
 
+### dependencies
+
+You need 
+* curl
+* node 22.21.1
+* git
+
+on debian you can install the following:
+
+``` bash
+sudo apt-get install git curl
+curl -sL http://deb.nodesource.com/setup_22.x | sudo bash -
+sudo apt-get install -y nodejs
+```
+
+### install it
 Try to execute the following steps (from a shell):
 
-    sudo apt-get install git curl
-    curl -sL http://deb.nodesource.com/setup_22.x | sudo bash -
-    sudo apt-get install -y nodejs
-    git clone https://code.03c8.net/KrakensLab/oasis
-    cd oasis
-    npm install .
-    
+``` bash
+git clone https://code.03c8.net/KrakensLab/oasis
+cd oasis
+npm install .
+```
 ---
 
 ## 3) Run Oasis

--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,16 @@ printf "==========================\n"
 printf "|| OASIS Installer v0.2 ||\n"
 printf "==========================\n"
 
-sudo apt-get install -y git curl tar
-
-curl -sL http://deb.nodesource.com/setup_22.x | sudo bash -
-sudo apt-get install -y nodejs
+read -p "Install dependencies? (debian, ubuntu, mint and all debian like distribution only) [Y/n]" -n 1 -r
+echo    
+REPLY=${REPLY:-y}
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  sudo apt-get install -y git curl tar
+  
+  curl -sL http://deb.nodesource.com/setup_22.x | sudo bash -
+  sudo apt-get install -y nodejs
+fi
 npm install .
 npm audit fix
 


### PR DESCRIPTION
Allow to install with the script with non debian system.

The script ask if you need to install dependencies, if no it skip it.

install.md documentation has been updated accordingly. 